### PR TITLE
fixed incompatibility with nasm v. <2.15 and with 64bit platform

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,11 @@ F=nasmjf
 
 # assemble and link! (-g enables debugging symbols)
 nasm -f elf32 -g -o $F.o $F.asm
-ld $F.o -o $F
+if [ $(uname -m | grep 64) ]; then
+  ld -m elf_i386 $F.o -s -o $F
+else
+  ld $F.o -o $F
+fi
 rm $F.o
 
 if [[ $1 == 'gdb' ]]

--- a/nasmjf.asm
+++ b/nasmjf.asm
@@ -662,7 +662,7 @@ _WORD:
 
 SECTION .data
 word_buffer:
-    db 32 dup (0) ; 32 bytes of buffer for word names
+    times 32 db 0x0 ; 32 bytes of buffer for word names
 SECTION .text
 
 ; +----------------------------------------------------------------------------+


### PR DESCRIPTION
this changes the definition of the **word buffer** in nasmjf.asm to use the older `times` rather than the `dup` syntax wich was only added on nasm version 2.15. [[source](https://stackoverflow.com/questions/64235907/comma-expected-after-operand-1-when-defining-a-series-of-bytes-in-nasm)]

it also changes the **build.sh** script to let `ld` choose to emulate the i386 (32bit) elf format on 64 bit systems. [[source](https://stackoverflow.com/questions/19200333/architecture-of-i386-input-file-is-incompatible-with-i386x86-64)]